### PR TITLE
Add news post: serving local LLMs for clinical and research use

### DIFF
--- a/src/content/news/en/2026-06-17_local-llms-for-clinical-and-research-use.md
+++ b/src/content/news/en/2026-06-17_local-llms-for-clinical-and-research-use.md
@@ -1,0 +1,77 @@
+---
+title: 'Serving Local LLMs for Clinical and Research Use at the Douglas'
+extendedTitle: 'Bringing Self-Hosted Large Language Models to the Douglas Mental Health University Institute'
+description: The Douglas Neuroinformatics Platform is deploying open-weight models — Gemma 4, MedGemma 3, MedGemma 4, and Qwen 3.6 — served locally with vLLM, keeping sensitive patient and research data inside the institute.
+authors:
+  - gabriel-devenyi
+type: article
+---
+
+Large language models have quickly become part of everyday clinical and research work, from drafting documentation to summarizing literature and exploring data. But the most capable commercial models are hosted by third parties, and using them means sending your text — including, potentially, sensitive patient information — to servers outside your institution's control. For a mental health hospital, that is a problem worth solving rather than accepting.
+
+The Douglas Neuroinformatics Platform is addressing it directly: we are deploying open-weight large language models on our own hardware, served locally to clinicians and researchers at the Douglas Mental Health University Institute. Nothing leaves the building.
+
+## The models
+
+We selected a set of complementary open-weight models to cover the range of clinical and research needs:
+
+- **Gemma 4** — Google's general-purpose open model, used as a capable all-rounder for drafting, summarization, coding assistance, and general question answering.
+- **MedGemma 3** and **MedGemma 4** — medically-tuned variants designed for clinical text and biomedical reasoning. Running both generations lets us compare quality and behaviour while giving users a model trained specifically on medical content.
+- **Qwen 3.6** — a strong multilingual model, valuable in a bilingual French/English setting and competitive on reasoning and coding tasks.
+
+Offering several models matters. No single model is best at everything, and being able to route a clinical summarization task to MedGemma while sending a multilingual or coding task to Qwen or Gemma gives users the right tool without compromise.
+
+## Serving with vLLM
+
+All of these models are served through [vLLM](https://github.com/vllm-project/vllm), an inference engine built for high-throughput, low-latency serving. vLLM's continuous batching and paged attention let a single GPU server handle many concurrent users efficiently, and its OpenAI-compatible API means existing tools and scripts work against our local endpoint with minimal changes — point them at our internal URL instead of a vendor's.
+
+That compatibility is a deliberate choice. Researchers can keep using the libraries and editor integrations they already know, and clinicians get familiar chat interfaces, while every request is quietly handled inside the institute.
+
+## Why local matters: patient data safety
+
+The central reason for this work is data safety. Mental health records are among the most sensitive data a hospital holds, and they carry both legal protection and a strong ethical obligation. Sending that data to an external API creates real risks:
+
+- **Loss of control.** Once text leaves the network, you cannot guarantee where it is stored, how long it is retained, or who can access it. Provider terms change, and "we don't train on your data" is a promise, not a technical guarantee.
+- **Regulatory exposure.** Quebec's health privacy law and broader Canadian privacy frameworks place strict limits on disclosing personal health information. Routing it through a third-party LLM can constitute a disclosure the institution is not authorized to make.
+- **Re-identification.** Clinical free text is notoriously hard to de-identify reliably. Even text that looks anonymized can leak identifying detail, so "just remove the names" is not a safe mitigation.
+
+Self-hosting removes these risks at the source. When the model runs on hardware the platform administers, on the institute's own network:
+
+- **Data never leaves.** Prompts and responses stay on local infrastructure. There is no external transmission to audit, secure, or trust.
+- **We control retention.** Logs, caches, and history are governed by our own policies, not a vendor's defaults.
+- **Access is auditable.** Authentication and usage run through systems the institute already operates, so access can be governed and reviewed like any other internal clinical system.
+- **No training leakage.** Open-weight models served locally do not feed user input back into anyone's training pipeline.
+
+The result is that a clinician can use an LLM to help draft a note or summarize a chart, and a researcher can analyze sensitive study data with model assistance, without either of them having to weigh productivity against the risk of exposing patient information. The safe option becomes the default option.
+
+## Helping groups remove PII from their data
+
+Local serving solves the transmission problem, but many research and clinical groups also need to clean identifying information out of their own datasets before they share, analyze, or archive them. This is hard to do well by hand, and "just delete the names" misses dates, addresses, record numbers, and the many other ways a person can be identified in free text. The platform helps groups with this directly.
+
+We support PII removal using two open token-classification models built for the task:
+
+- **[openai/privacy-filter](https://huggingface.co/openai/privacy-filter)** — a ~1.4B-parameter model that tags personally identifiable information (names, dates, addresses, identifiers, and similar spans) in text. It is fast and Apache-2.0 licensed.
+- **[OpenMed/privacy-filter-multilingual](https://huggingface.co/OpenMed/privacy-filter-multilingual)** — a fine-tune of the same architecture that extends PII detection across 16 languages, including both French and English, trained on the ai4privacy PII-masking datasets. In a bilingual institute, this matters: a redactor that only understands English would silently miss identifiers in French clinical text.
+
+These models do token classification rather than generation, so they pinpoint *where* the sensitive spans are without rewriting the surrounding content. That lets a group apply the policy it needs — redact, pseudonymize, or flag — and review the results before anything is published or moved. The bilingual model handles our French/English mix; the base model gives a well-tested option for English-heavy datasets.
+
+Like the language models, these run locally, so the data being cleaned never leaves the institute during the process. The platform works with each group to fit the tools to their data and workflow, turning de-identification from a manual chore into a supported, repeatable step.
+
+## What's next
+
+This deployment is the foundation for a broader set of tools — retrieval over internal documents, structured extraction from clinical text, and research-focused assistants — all built on infrastructure that keeps data where it belongs. As open-weight models continue to improve, a locally-served stack lets the Douglas adopt new capabilities on its own terms, without renegotiating data safety every time.
+
+Local LLMs are not a compromise on capability. They are how a mental health institute gets the benefits of modern AI while keeping its first obligation — protecting the people in its care — intact.
+
+## Why a team like the DNP is essential
+
+None of this happens by default. Selecting models, standing up GPU servers, configuring vLLM, securing the endpoints, integrating authentication, supporting bilingual PII removal, and keeping it all running is specialized work that sits well outside the training of clinicians and researchers — and outside what most of them have the time or mandate to take on. Left to individuals, the practical choice collapses to two bad options: paste sensitive data into whatever commercial tool is easiest, or go without modern AI entirely.
+
+A dedicated neuroinformatics team removes that dilemma. The Douglas Neuroinformatics Platform exists precisely to carry this technical and operational burden on behalf of the institute:
+
+- **Infrastructure.** Procuring and running the GPU hardware, inference engine, and serving stack so a model is just an endpoint a user can call.
+- **Security and governance.** Handling authentication, access control, logging policy, and the privacy engineering that keeps deployments compliant with health-data obligations.
+- **Expertise and curation.** Tracking the fast-moving open-weight landscape, evaluating which models are worth deploying, and retiring them as better ones arrive — so users get current capability without having to follow the field themselves.
+- **Support.** Working directly with clinical and research groups to fit these tools to real workflows, from de-identification to model-assisted analysis.
+
+This is the core argument for embedding a platform like the DNP inside a research hospital. The capabilities described here — capable local models, served safely, with privacy support for the people who use them — are not realistically available to a clinician or researcher acting alone. They become available when an institution invests in a team whose job is to build, secure, and sustain them. That team is what turns "modern AI, but only if you accept the privacy risk" into "modern AI, on infrastructure you can trust."

--- a/src/content/news/en/2026-06-17_local-llms-for-clinical-and-research-use.md
+++ b/src/content/news/en/2026-06-17_local-llms-for-clinical-and-research-use.md
@@ -15,9 +15,9 @@ The Douglas Neuroinformatics Platform is addressing it directly: we are deployin
 
 We selected a set of complementary open-weight models to cover the range of clinical and research needs:
 
-- **Gemma 4** — Google's general-purpose open model, used as a capable all-rounder for drafting, summarization, coding assistance, and general question answering.
-- **MedGemma 3** and **MedGemma 4** — medically-tuned variants designed for clinical text and biomedical reasoning. Running both generations lets us compare quality and behaviour while giving users a model trained specifically on medical content.
-- **Qwen 3.6** — a strong multilingual model, valuable in a bilingual French/English setting and competitive on reasoning and coding tasks.
+- **[Gemma 4](https://huggingface.co/google/gemma-4-31B-it)** — Google's general-purpose open model, used as a capable all-rounder for drafting, summarization, coding assistance, and general question answering.
+- **[MedGemma 3](https://huggingface.co/google/medgemma-27b-it)** and **[MedGemma 4](https://huggingface.co/google/medgemma-1.5-4b-it)** — medically-tuned variants designed for clinical text and biomedical reasoning. Running both generations lets us compare quality and behaviour while giving users a model trained specifically on medical content.
+- **[Qwen 3.6](https://huggingface.co/Qwen/Qwen3.6-27B)** — a strong multilingual model, valuable in a bilingual French/English setting and competitive on reasoning and coding tasks.
 
 Offering several models matters. No single model is best at everything, and being able to route a clinical summarization task to MedGemma while sending a multilingual or coding task to Qwen or Gemma gives users the right tool without compromise.
 

--- a/src/content/news/fr/2026-06-17_local-llms-for-clinical-and-research-use.md
+++ b/src/content/news/fr/2026-06-17_local-llms-for-clinical-and-research-use.md
@@ -15,9 +15,9 @@ La Plateforme de neuroinformatique Douglas s’y attaque directement : nous dép
 
 Nous avons retenu un ensemble de modèles à poids ouverts complémentaires pour couvrir l’éventail des besoins cliniques et de recherche :
 
-- **Gemma 4** — le modèle ouvert généraliste de Google, utilisé comme outil polyvalent pour la rédaction, la synthèse, l’assistance au code et les questions générales.
-- **MedGemma 3** et **MedGemma 4** — des variantes spécialisées en médecine, conçues pour le texte clinique et le raisonnement biomédical. Exécuter les deux générations nous permet de comparer leur qualité et leur comportement tout en offrant aux utilisateurs un modèle entraîné spécifiquement sur du contenu médical.
-- **Qwen 3.6** — un modèle multilingue performant, précieux dans un contexte bilingue français/anglais et compétitif en raisonnement et en programmation.
+- **[Gemma 4](https://huggingface.co/google/gemma-4-31B-it)** — le modèle ouvert généraliste de Google, utilisé comme outil polyvalent pour la rédaction, la synthèse, l’assistance au code et les questions générales.
+- **[MedGemma 3](https://huggingface.co/google/medgemma-27b-it)** et **[MedGemma 4](https://huggingface.co/google/medgemma-1.5-4b-it)** — des variantes spécialisées en médecine, conçues pour le texte clinique et le raisonnement biomédical. Exécuter les deux générations nous permet de comparer leur qualité et leur comportement tout en offrant aux utilisateurs un modèle entraîné spécifiquement sur du contenu médical.
+- **[Qwen 3.6](https://huggingface.co/Qwen/Qwen3.6-27B)** — un modèle multilingue performant, précieux dans un contexte bilingue français/anglais et compétitif en raisonnement et en programmation.
 
 Offrir plusieurs modèles a son importance. Aucun modèle unique n’excelle en tout, et pouvoir diriger une tâche de synthèse clinique vers MedGemma tout en envoyant une tâche multilingue ou de code vers Qwen ou Gemma donne aux utilisateurs le bon outil sans compromis.
 

--- a/src/content/news/fr/2026-06-17_local-llms-for-clinical-and-research-use.md
+++ b/src/content/news/fr/2026-06-17_local-llms-for-clinical-and-research-use.md
@@ -1,0 +1,77 @@
+---
+title: 'Déploiement local de grands modèles de langage pour un usage clinique et de recherche au Douglas'
+extendedTitle: 'Mettre des grands modèles de langage auto-hébergés au service de l’Institut universitaire en santé mentale Douglas'
+description: La Plateforme de neuroinformatique Douglas déploie des modèles à poids ouverts — Gemma 4, MedGemma 3, MedGemma 4 et Qwen 3.6 — servis localement avec vLLM, gardant les données sensibles des patients et de la recherche à l’intérieur de l’institut.
+authors:
+  - gabriel-devenyi
+type: article
+---
+
+Les grands modèles de langage font désormais partie du travail clinique et de recherche au quotidien : rédaction de documentation, synthèse de la littérature, exploration de données. Mais les modèles commerciaux les plus performants sont hébergés par des tiers, et les utiliser signifie envoyer son texte — y compris, potentiellement, des renseignements sensibles sur les patients — vers des serveurs hors du contrôle de l’établissement. Pour un hôpital en santé mentale, c’est un problème à résoudre plutôt qu’à accepter.
+
+La Plateforme de neuroinformatique Douglas s’y attaque directement : nous déployons des grands modèles de langage à poids ouverts sur notre propre matériel, servis localement aux cliniciens et aux chercheurs de l’Institut universitaire en santé mentale Douglas. Rien ne sort des murs.
+
+## Les modèles
+
+Nous avons retenu un ensemble de modèles à poids ouverts complémentaires pour couvrir l’éventail des besoins cliniques et de recherche :
+
+- **Gemma 4** — le modèle ouvert généraliste de Google, utilisé comme outil polyvalent pour la rédaction, la synthèse, l’assistance au code et les questions générales.
+- **MedGemma 3** et **MedGemma 4** — des variantes spécialisées en médecine, conçues pour le texte clinique et le raisonnement biomédical. Exécuter les deux générations nous permet de comparer leur qualité et leur comportement tout en offrant aux utilisateurs un modèle entraîné spécifiquement sur du contenu médical.
+- **Qwen 3.6** — un modèle multilingue performant, précieux dans un contexte bilingue français/anglais et compétitif en raisonnement et en programmation.
+
+Offrir plusieurs modèles a son importance. Aucun modèle unique n’excelle en tout, et pouvoir diriger une tâche de synthèse clinique vers MedGemma tout en envoyant une tâche multilingue ou de code vers Qwen ou Gemma donne aux utilisateurs le bon outil sans compromis.
+
+## Le service avec vLLM
+
+Tous ces modèles sont servis au moyen de [vLLM](https://github.com/vllm-project/vllm), un moteur d’inférence conçu pour un service à haut débit et à faible latence. Le traitement par lots continu (continuous batching) et l’attention paginée (paged attention) de vLLM permettent à un seul serveur GPU de gérer efficacement de nombreux utilisateurs simultanés, et son API compatible avec celle d’OpenAI fait que les outils et scripts existants fonctionnent avec notre point d’accès local moyennant des modifications minimes — il suffit de les pointer vers notre URL interne plutôt que vers celle d’un fournisseur.
+
+Cette compatibilité est un choix délibéré. Les chercheurs peuvent continuer à utiliser les bibliothèques et les intégrations d’éditeur qu’ils connaissent déjà, et les cliniciens disposent d’interfaces de clavardage familières, pendant que chaque requête est discrètement traitée à l’intérieur de l’institut.
+
+## Pourquoi le local est important : la sécurité des données des patients
+
+La raison centrale de ce travail est la sécurité des données. Les dossiers de santé mentale comptent parmi les données les plus sensibles que détient un hôpital, et ils portent à la fois une protection juridique et une forte obligation éthique. Envoyer ces données vers une API externe crée des risques réels :
+
+- **Perte de contrôle.** Une fois que le texte quitte le réseau, on ne peut plus garantir où il est stocké, combien de temps il est conservé, ni qui peut y accéder. Les conditions des fournisseurs changent, et « nous n’entraînons pas nos modèles sur vos données » est une promesse, pas une garantie technique.
+- **Exposition réglementaire.** La loi québécoise sur la protection des renseignements de santé et les cadres canadiens plus larges imposent des limites strictes à la divulgation de renseignements personnels de santé. Les faire transiter par un grand modèle de langage tiers peut constituer une divulgation que l’établissement n’est pas autorisé à faire.
+- **Ré-identification.** Le texte clinique libre est notoirement difficile à dépersonnaliser de façon fiable. Même un texte qui semble anonymisé peut laisser filtrer des détails identifiants : « il suffit d’enlever les noms » n’est pas une mesure d’atténuation sûre.
+
+L’auto-hébergement élimine ces risques à la source. Lorsque le modèle s’exécute sur du matériel administré par la plateforme, sur le réseau de l’institut :
+
+- **Les données ne sortent jamais.** Les requêtes et les réponses demeurent sur l’infrastructure locale. Il n’y a aucune transmission externe à auditer, à sécuriser ou à laquelle se fier.
+- **Nous contrôlons la conservation.** Les journaux, les caches et l’historique sont régis par nos propres politiques, et non par les paramètres par défaut d’un fournisseur.
+- **Les accès sont auditables.** L’authentification et l’utilisation passent par des systèmes que l’institut exploite déjà, de sorte que les accès peuvent être gouvernés et révisés comme ceux de tout autre système clinique interne.
+- **Aucune fuite vers l’entraînement.** Les modèles à poids ouverts servis localement ne réinjectent pas les entrées des utilisateurs dans le pipeline d’entraînement de qui que ce soit.
+
+Résultat : un clinicien peut utiliser un modèle de langage pour aider à rédiger une note ou résumer un dossier, et un chercheur peut analyser des données d’étude sensibles avec l’aide d’un modèle, sans que l’un ou l’autre ait à arbitrer entre productivité et risque d’exposer des renseignements sur les patients. L’option sûre devient l’option par défaut.
+
+## Aider les groupes à retirer les RP de leurs données
+
+Le service local règle le problème de la transmission, mais de nombreux groupes de recherche et cliniques doivent aussi nettoyer les renseignements identifiants de leurs propres jeux de données avant de les partager, de les analyser ou de les archiver. C’est difficile à faire correctement à la main, et « il suffit d’effacer les noms » laisse passer les dates, les adresses, les numéros de dossier et les nombreuses autres façons d’identifier une personne dans du texte libre. La plateforme aide les groupes dans cette tâche directement.
+
+Nous appuyons le retrait des renseignements personnels (RP) à l’aide de deux modèles ouverts de classification de jetons conçus pour cette fin :
+
+- **[openai/privacy-filter](https://huggingface.co/openai/privacy-filter)** — un modèle d’environ 1,4 milliard de paramètres qui repère les renseignements personnels identifiables (noms, dates, adresses, identifiants et autres segments semblables) dans le texte. Il est rapide et sous licence Apache 2.0.
+- **[OpenMed/privacy-filter-multilingual](https://huggingface.co/OpenMed/privacy-filter-multilingual)** — un ajustement fin de la même architecture qui étend la détection des RP à 16 langues, dont le français et l’anglais, entraîné sur les jeux de données de masquage de RP d’ai4privacy. Dans un institut bilingue, cela compte : un outil de caviardage qui ne comprend que l’anglais manquerait silencieusement les identifiants dans le texte clinique en français.
+
+Ces modèles font de la classification de jetons plutôt que de la génération : ils localisent donc *où* se trouvent les segments sensibles sans réécrire le contenu environnant. Un groupe peut ainsi appliquer la politique qu’il lui faut — caviarder, pseudonymiser ou signaler — et réviser les résultats avant toute publication ou tout transfert. Le modèle bilingue gère notre mélange français/anglais; le modèle de base offre une option éprouvée pour les jeux de données surtout anglophones.
+
+Comme les modèles de langage, ces outils s’exécutent localement, de sorte que les données nettoyées ne quittent jamais l’institut pendant le processus. La plateforme travaille avec chaque groupe pour adapter les outils à ses données et à son flux de travail, transformant la dépersonnalisation d’une corvée manuelle en une étape soutenue et reproductible.
+
+## La suite
+
+Ce déploiement est la fondation d’un ensemble plus large d’outils — recherche documentaire interne, extraction structurée à partir de texte clinique, assistants axés sur la recherche — tous bâtis sur une infrastructure qui garde les données là où elles doivent rester. À mesure que les modèles à poids ouverts s’améliorent, une pile servie localement permet au Douglas d’adopter de nouvelles capacités selon ses propres conditions, sans renégocier la sécurité des données à chaque fois.
+
+Les modèles de langage locaux ne sont pas un compromis sur la capacité. Ils sont la façon dont un institut en santé mentale tire profit de l’IA moderne tout en préservant intacte sa première obligation : protéger les personnes dont il a la charge.
+
+## Pourquoi une équipe comme la PNI est essentielle
+
+Rien de tout cela ne se fait par défaut. Sélectionner des modèles, monter des serveurs GPU, configurer vLLM, sécuriser les points d’accès, intégrer l’authentification, soutenir le retrait bilingue des RP et faire fonctionner l’ensemble est un travail spécialisé qui dépasse largement la formation des cliniciens et des chercheurs — et au-delà de ce que la plupart d’entre eux ont le temps ou le mandat d’assumer. Laissée aux individus, la décision pratique se réduit à deux mauvaises options : coller des données sensibles dans le premier outil commercial venu, ou se passer entièrement de l’IA moderne.
+
+Une équipe de neuroinformatique dédiée fait disparaître ce dilemme. La Plateforme de neuroinformatique Douglas existe précisément pour porter ce fardeau technique et opérationnel au nom de l’institut :
+
+- **Infrastructure.** Acquérir et exploiter le matériel GPU, le moteur d’inférence et la pile de service pour qu’un modèle ne soit qu’un point d’accès que l’utilisateur peut appeler.
+- **Sécurité et gouvernance.** Gérer l’authentification, le contrôle d’accès, la politique de journalisation et l’ingénierie de la confidentialité qui maintiennent les déploiements conformes aux obligations relatives aux données de santé.
+- **Expertise et curation.** Suivre l’évolution rapide des modèles à poids ouverts, évaluer lesquels méritent d’être déployés et les retirer à mesure que de meilleurs arrivent — pour que les utilisateurs disposent de capacités à jour sans avoir à suivre le domaine eux-mêmes.
+- **Soutien.** Travailler directement avec les groupes cliniques et de recherche pour adapter ces outils à des flux de travail réels, de la dépersonnalisation à l’analyse assistée par modèle.
+
+C’est l’argument central en faveur de l’intégration d’une plateforme comme la PNI au sein d’un hôpital de recherche. Les capacités décrites ici — des modèles locaux performants, servis de façon sûre, avec un soutien à la confidentialité pour ceux qui les utilisent — ne sont pas réellement accessibles à un clinicien ou à un chercheur agissant seul. Elles le deviennent lorsqu’un établissement investit dans une équipe dont le travail consiste à les bâtir, à les sécuriser et à les maintenir. C’est cette équipe qui transforme « l’IA moderne, mais seulement si vous acceptez le risque pour la vie privée » en « l’IA moderne, sur une infrastructure à laquelle vous pouvez vous fier ».


### PR DESCRIPTION
## Summary
Adds a news/blog article (EN + FR) on the DNP's local LLM deployment at the Douglas.

- **Models**: Gemma 4, MedGemma 3, MedGemma 4, Qwen 3.6
- **Serving**: vLLM (continuous batching, paged attention, OpenAI-compatible API)
- **Patient data safety**: rationale for self-hosting — no external transmission, Quebec/Canada health-privacy obligations, re-identification risk, retention control, no training leakage
- **PII removal support**: platform helps groups de-identify their data using [openai/privacy-filter](https://huggingface.co/openai/privacy-filter) and [OpenMed/privacy-filter-multilingual](https://huggingface.co/OpenMed/privacy-filter-multilingual) (bilingual FR/EN)
- **Why the DNP**: argues a dedicated neuroinformatics team is needed to deploy, secure, and sustain capabilities otherwise unavailable to clinicians/researchers

Files:
- `src/content/news/en/2026-06-17_local-llms-for-clinical-and-research-use.md`
- `src/content/news/fr/2026-06-17_local-llms-for-clinical-and-research-use.md`

## Testing
- `pnpm astro check` — 0 errors, 0 warnings, 0 hints
- `pnpm build` — 19 pages built, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)