### PR TITLE
Add Alumni section to Team page

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -77,7 +77,7 @@ export const collections = {
           }),
           seniority: z.number().positive().int(),
           suffix: z.enum(['MD', 'PhD']).optional(),
-          type: z.enum(['core-team-member', 'd3sm-coordinator'])
+          type: z.enum(['core-team-member', 'd3sm-coordinator', 'alumni'])
         })
       ]);
     },

--- a/src/content/team/gowree-tillousing.yaml
+++ b/src/content/team/gowree-tillousing.yaml
@@ -7,4 +7,4 @@ description:
   en: Gowree serves as a program coordinator for the D3SM Initiative, where she plays a key role in advancing the Open Data Capture project, primarily in collaboration with the Alliance en santé mentale du Québec.
   fr: Gowree est coordinatrice de programme pour l'initiative D3SM. Elle joue un rôle clé dans l'avancement du projet Open Data Capture, principalement en collaboration avec l'Alliance en santé mentale du Québec.
 seniority: 10
-type: d3sm-coordinator
+type: alumni

--- a/src/content/team/vanessa-valiquette.yaml
+++ b/src/content/team/vanessa-valiquette.yaml
@@ -7,4 +7,4 @@ description:
   en: Vanessa is a program coordinator for the D3SM Initiative, where she plays a vital role in facilitating communication between the DNP and other initiatives at the Douglas and throughout Quebec.
   fr: Vanessa est la coordonnatrice de programme pour l'initiative D3SM, où elle joue un rôle essentiel en facilitant la communication entre le DNP et d'autres initiatives au Douglas et à travers le Québec.
 seniority: 5
-type: d3sm-coordinator
+type: alumni

--- a/src/content/team/weijie-tan.yaml
+++ b/src/content/team/weijie-tan.yaml
@@ -7,4 +7,4 @@ description:
   en: Weijie is junior developer primarily working on the Douglas Data Bank project. He has developed multiple instruments and contributed to shared libraries used by Open Data Capture.
   fr: Weijie est un développeur junior qui travaille principalement sur le projet Douglas Data Bank. Il a développé de nombreux instruments et contribué aux bibliothèques partagées utilisées par Open Data Capture.
 seniority: 7
-type: core-team-member
+type: alumni

--- a/src/pages/[locale]/team.astro
+++ b/src/pages/[locale]/team.astro
@@ -25,6 +25,7 @@ team.sort((a, b) => {
 
 const coreTeam = team.filter(({ type }) => type === 'core-team-member');
 const d3smCoordinators = team.filter(({ type }) => type === 'd3sm-coordinator');
+const alumni = team.filter(({ type }) => type === 'alumni');
 
 export const getStaticPaths = () => {
   return [{ params: { locale: 'en' } }, { params: { locale: 'fr' } }];
@@ -73,6 +74,17 @@ const { t } = useTranslations(Astro.url);
       title={t({
         en: 'Program Coordinators',
         fr: 'Coordinatrices de projet'
+      })}
+    />
+    <TeamMembers
+      people={alumni}
+      description={t({
+        en: 'These are former members of the Douglas Neuroinformatics Platform team who have contributed to our projects and mission.',
+        fr: "Il s'agit d'anciens membres de l'équipe de la Douglas Neuroinformatics Platform qui ont contribué à nos projets et à notre mission."
+      })}
+      title={t({
+        en: 'Alumni',
+        fr: 'Anciens membres'
       })}
     />
   </div>


### PR DESCRIPTION
Add a new Alumni section to the Team page and move Gowree Tillousing, Weijie Tan, and Vanessa Valiquette there.

- Extend the team `type` enum in `config.ts` with `'alumni'`
- Reclassify the three members as `alumni`
- Add a new `<TeamMembers>` section ("Alumni" / "Anciens membres") at the bottom of the page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Alumni" section to the team page to showcase former team members with localized content.

* **Updates**
  * Three team members have been migrated to alumni status and now appear in the newly created alumni section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->