### PR TITLE
Add ODC Instruments to Projects page

### DIFF
--- a/src/content/projects/odc-instruments.yaml
+++ b/src/content/projects/odc-instruments.yaml
@@ -1,0 +1,16 @@
+title:
+  en: ODC Instruments
+  fr: Instruments ODC
+description:
+  en: A curated collection of open-access data-collection instruments — forms and interactive tasks — for the Open Data Capture platform. Each instrument is self-contained and validated, and can be previewed in the online playground or served locally for development.
+  fr: Une collection organisée d'instruments de collecte de données en accès libre — formulaires et tâches interactives — pour la plateforme Open Data Capture. Chaque instrument est autonome et validé, et peut être prévisualisé dans le terrain de jeu en ligne ou servi localement pour le développement.
+dateCompleted: ~
+contributors:
+  - joshua-unrau
+  - david-roper
+  - gabriel-devenyi
+technologies:
+  - typescript
+  - javascript
+  - nodejs
+link: https://github.com/DouglasNeuroInformatics/ODC_Instruments


### PR DESCRIPTION
Adds a new entry to the Projects page for [ODC Instruments](https://github.com/DouglasNeuroInformatics/ODC_Instruments), a collection of open-access data-collection instruments for the Open Data Capture platform.